### PR TITLE
Add row details

### DIFF
--- a/src/main/java/org/octri/clinchit/controller/SdhController.java
+++ b/src/main/java/org/octri/clinchit/controller/SdhController.java
@@ -19,6 +19,12 @@ public class SdhController {
 	@Autowired
 	PatientRepository patientRepository;
 	
+	/**
+	 * Show the Vue mockup
+	 * @param model
+	 * @param id
+	 * @return
+	 */
 	@GetMapping("patient/{id}/sdh")
 	public ModelAndView sdh(Map<String, Object> model, @PathVariable Long id) {
 
@@ -26,6 +32,20 @@ public class SdhController {
 		model.put("patient", patient);
 		model.put("pageScripts", new String[] {"sdh"});
 		return new ModelAndView("sdh", model);
+	}
+
+	/**
+	 * Show the static mockup
+	 * @param model
+	 * @param id
+	 * @return
+	 */
+	@GetMapping("patient/{id}/sdh-mockup")
+	public ModelAndView sdhMockup(Map<String, Object> model, @PathVariable Long id) {
+
+		Patient patient = patientRepository.findById(id).get();
+		model.put("patient", patient);
+		return new ModelAndView("sdh-mockup", model);
 	}
 
 }

--- a/src/main/resources/mustache-templates/sdh-mockup.mustache
+++ b/src/main/resources/mustache-templates/sdh-mockup.mustache
@@ -1,0 +1,139 @@
+{{>layout/header}}
+
+<div class="container vertical-space">
+	{{#patient}}
+		<h3>Patient Info</h3> 
+		Name: {{#name}}{{.}}{{/name}}<br>
+		Date of Birth: {{#dateOfBirth}}{{.}}{{/dateOfBirth}}<br>		
+	{{/patient}}
+	<br>
+	<h3>Social Determinants of Health</h3>	
+	<table class="table">
+    	<thead class="thead-dark">
+    		<tr>
+    			<th>Domain</th>
+    			<th>Date Last Assessed</th>
+    			<th>Clinician Priority</th>
+    			<th>Patient Readiness</th>
+    		</tr>
+    	</thead>
+    	<tbody>
+    		<tr data-toggle="collapse" data-target="#collapseOne" class="clickable collapse-row collapsed">
+    			<td><i class="fas fa-angle-right"></i> Food Security</td>
+    			<td>01/01/2019</td>
+    			<td class="text-danger">High</td>
+    			<td class="text-warning">Motivated</td>
+    		</tr>
+    		<tr>
+            	<td colspan="4">
+                	<div id="collapseOne" class="collapse">
+                		<ul class="nav nav-tabs">
+  							<li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#current">Current Questionnaire Response</a></li>
+  							<li class="nav-item"><a class="nav-link" data-toggle="tab" href="#historic">Historic Questionnaire Response</a></li>
+                		</ul>
+                		<div class="tab-content">
+  							<div class="tab-pane container active" id="current">
+  								<br>
+		                 		<table>
+		                			<tbody>
+		                				<tr>
+		                					<td>1. In the last 12 months, were you worried that your food would run out before you got money to buy more?</td>
+		                					<td>Y</td>
+		                				</tr>
+		                				<tr>
+		                					<td>2. In the last 12 months, did you ever eat less than you felt you should because there wasn’t enough money for food?</td>
+		                					<td>Y</td>
+		                				</tr>
+		                				<tr>
+		                					<td>3. In the last 12 months, were you every hungry but didn’t eat because there wasn’t enough money for food?</td>
+		                					<td>N</td>
+		                				</tr>
+		                				<tr>
+		                					<td>4. In the last 12 months, since last (name of current month), did (you/you or other adults in your household) ever cut the size of your meals or skip meals because there wasn’t enough money for food?</td>
+		                					<td>Y</td>
+		                				</tr>
+		                			</tbody>
+		                		</table>                	
+  							
+  							</div>
+  							<div class="tab-pane container" id="historic">
+  								<br><p>This might be a clickable list of dates or the menu item might be a dropdown.</p>
+  							</div>
+						</div>
+                	</div>
+            	</td>
+        	</tr>
+     		<tr data-toggle="collapse" data-target="#collapseTwo" class="clickable collapse-row collapsed">
+   				<td><i class="fas fa-angle-right"></i> Transportation</td>
+    			<td>11/19/2018</td>
+    			<td class="text-warning">Medium</td>
+    			<td class="text-success">Ready</td>
+    		</tr>
+    		<tr>
+            	<td colspan="4">
+                	<div id="collapseTwo" class="collapse">Questions Related to Transportation</div>
+            	</td>
+        	</tr>
+    		<tr data-toggle="collapse" data-target="#collapseThree" class="clickable collapse-row collapsed">
+    			<td><i class="fas fa-angle-right"></i> Housing Instability</td>
+    			<td>N/A</td>
+    			<td></td>
+    			<td></td>
+    		</tr>
+    		<tr>
+            	<td colspan="4">
+                	<div id="collapseThree" class="collapse">Questions Related to Housing Instability</div>
+            	</td>
+        	</tr>
+     		<tr data-toggle="collapse" data-target="#collapseFour" class="clickable collapse-row collapsed">
+   				<td><i class="fas fa-angle-right"></i> Utilities</td>
+    			<td>12/16/2018</td>
+    			<td class="text-warning">Medium</td>
+    			<td class="text-danger">Not Ready</td>
+    		</tr>
+    		<tr>
+            	<td colspan="4">
+                	<div id="collapseFour" class="collapse">Questions Related to Utilities</div>
+            	</td>
+        	</tr>
+     		<tr data-toggle="collapse" data-target="#collapseFive" class="clickable collapse-row collapsed">
+   				<td><i class="fas fa-angle-right"></i> Interpersonal Violence</td>
+    			<td>04/02/2017</td>
+    			<td class="text-success">Low</td>
+    			<td class="text-warning">Motivated</td>
+    		</tr>
+    		<tr>
+            	<td colspan="4">
+                	<div id="collapseFive" class="collapse">Questions Related to Interpersonal Violence</div>
+            	</td>
+        	</tr>
+     		<tr data-toggle="collapse" data-target="#collapseSix" class="clickable collapse-row collapsed">
+   				<td><i class="fas fa-angle-right"></i> Education</td>
+    			<td>11/19/2018</td>
+    			<td class="text-warning">Medium</td>
+    			<td class="text-success">Ready</td>
+    		</tr>
+    		<tr>
+            	<td colspan="4">
+                	<div id="collapseSix" class="collapse">Questions Related to Education</div>
+            	</td>
+        	</tr>
+     		<tr data-toggle="collapse" data-target="#collapseSeven" class="clickable collapse-row collapsed">
+   				<td><i class="fas fa-angle-right"></i> Financial Strain</td>
+    			<td>11/19/2018</td>
+    			<td class="text-success">Low</td>
+    			<td class="text-success">Ready</td>
+    		</tr>
+    		<tr>
+            	<td colspan="4">
+                	<div id="collapseSeven" class="collapse">Questions Related to Financial Strain</div>
+            	</td>
+        	</tr>
+    	</tbody>
+	</table>	
+
+</div>
+
+<br>
+
+{{>layout/footer}}

--- a/src/main/resources/mustache-templates/sdh.mustache
+++ b/src/main/resources/mustache-templates/sdh.mustache
@@ -7,145 +7,56 @@
 		Date of Birth: {{#dateOfBirth}}{{.}}{{/dateOfBirth}}<br>		
 	{{/patient}}
 	<br>
-	<h3>Social Determinants of Health (static)</h3>	
-	<table class="table">
-    	<thead class="thead-dark">
-    		<tr>
-    			<th>Domain</th>
-    			<th>Date Last Assessed</th>
-    			<th>Clinician Priority</th>
-    			<th>Patient Readiness</th>
-    		</tr>
-    	</thead>
-    	<tbody>
-    		<tr data-toggle="collapse" data-target="#collapseOne" class="clickable collapse-row collapsed">
-    			<td><i class="fas fa-angle-right"></i> Food Security</td>
-    			<td>01/01/2019</td>
-    			<td class="text-danger">High</td>
-    			<td class="text-warning">Motivated</td>
-    		</tr>
-    		<tr>
-            	<td colspan="4">
-                	<div id="collapseOne" class="collapse">
-                		<ul class="nav nav-tabs">
-  							<li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#current">Current Questionnaire Response</a></li>
-  							<li class="nav-item"><a class="nav-link" data-toggle="tab" href="#historic">Historic Questionnaire Response</a></li>
-                		</ul>
-                		<div class="tab-content">
-  							<div class="tab-pane container active" id="current">
-  								<br>
-		                 		<table>
-		                			<tbody>
-		                				<tr>
-		                					<td>1. In the last 12 months, were you worried that your food would run out before you got money to buy more?</td>
-		                					<td>Y</td>
-		                				</tr>
-		                				<tr>
-		                					<td>2. In the last 12 months, did you ever eat less than you felt you should because there wasn’t enough money for food?</td>
-		                					<td>Y</td>
-		                				</tr>
-		                				<tr>
-		                					<td>3. In the last 12 months, were you every hungry but didn’t eat because there wasn’t enough money for food?</td>
-		                					<td>N</td>
-		                				</tr>
-		                				<tr>
-		                					<td>4. In the last 12 months, since last (name of current month), did (you/you or other adults in your household) ever cut the size of your meals or skip meals because there wasn’t enough money for food?</td>
-		                					<td>Y</td>
-		                				</tr>
-		                			</tbody>
-		                		</table>                	
-  							
-  							</div>
-  							<div class="tab-pane container" id="historic">
-  								<br><p>This might be a clickable list of dates or the menu item might be a dropdown.</p>
-  							</div>
-						</div>
-                	</div>
-            	</td>
-        	</tr>
-     		<tr data-toggle="collapse" data-target="#collapseTwo" class="clickable collapse-row collapsed">
-   				<td><i class="fas fa-angle-right"></i> Transportation</td>
-    			<td>11/19/2018</td>
-    			<td class="text-warning">Medium</td>
-    			<td class="text-success">Ready</td>
-    		</tr>
-    		<tr>
-            	<td colspan="4">
-                	<div id="collapseTwo" class="collapse">Questions Related to Transportation</div>
-            	</td>
-        	</tr>
-    		<tr data-toggle="collapse" data-target="#collapseThree" class="clickable collapse-row collapsed">
-    			<td><i class="fas fa-angle-right"></i> Housing Instability</td>
-    			<td>N/A</td>
-    			<td></td>
-    			<td></td>
-    		</tr>
-    		<tr>
-            	<td colspan="4">
-                	<div id="collapseThree" class="collapse">Questions Related to Housing Instability</div>
-            	</td>
-        	</tr>
-     		<tr data-toggle="collapse" data-target="#collapseFour" class="clickable collapse-row collapsed">
-   				<td><i class="fas fa-angle-right"></i> Utilities</td>
-    			<td>12/16/2018</td>
-    			<td class="text-warning">Medium</td>
-    			<td class="text-danger">Not Ready</td>
-    		</tr>
-    		<tr>
-            	<td colspan="4">
-                	<div id="collapseFour" class="collapse">Questions Related to Utilities</div>
-            	</td>
-        	</tr>
-     		<tr data-toggle="collapse" data-target="#collapseFive" class="clickable collapse-row collapsed">
-   				<td><i class="fas fa-angle-right"></i> Interpersonal Violence</td>
-    			<td>04/02/2017</td>
-    			<td class="text-success">Low</td>
-    			<td class="text-warning">Motivated</td>
-    		</tr>
-    		<tr>
-            	<td colspan="4">
-                	<div id="collapseFive" class="collapse">Questions Related to Interpersonal Violence</div>
-            	</td>
-        	</tr>
-     		<tr data-toggle="collapse" data-target="#collapseSix" class="clickable collapse-row collapsed">
-   				<td><i class="fas fa-angle-right"></i> Education</td>
-    			<td>11/19/2018</td>
-    			<td class="text-warning">Medium</td>
-    			<td class="text-success">Ready</td>
-    		</tr>
-    		<tr>
-            	<td colspan="4">
-                	<div id="collapseSix" class="collapse">Questions Related to Education</div>
-            	</td>
-        	</tr>
-     		<tr data-toggle="collapse" data-target="#collapseSeven" class="clickable collapse-row collapsed">
-   				<td><i class="fas fa-angle-right"></i> Financial Strain</td>
-    			<td>11/19/2018</td>
-    			<td class="text-success">Low</td>
-    			<td class="text-success">Ready</td>
-    		</tr>
-    		<tr>
-            	<td colspan="4">
-                	<div id="collapseSeven" class="collapse">Questions Related to Financial Strain</div>
-            	</td>
-        	</tr>
-    	</tbody>
-	</table>	
 
-</div>
-
-<br>
-
-<h3>Social Determinants of Health (Vue)</h3>	
+	<h3>Social Determinants of Health</h3>
 	
-<div id="contents">
-	<b-table show-empty head-variant="dark" :items="emphasized" :fields="fields">
-	  <template slot="top-row" slot-scope="{ fields }">
-	    <td v-for="field in fields" :key="field.key">
-	      <input v-model="filters[field.key]" :placeholder="field.label">
-	    </td>
-	  </template>
-	</b-table>
+	<div id="contents">
+		<b-table show-empty head-variant="dark" :items="emphasized" :fields="fields">
+		  <template slot="top-row" slot-scope="{ fields }">
+		    <td v-for="field in fields" :key="field.key">
+		      <input v-model="filters[field.key]" :placeholder="field.label">
+		    </td>
+		  </template>
+     	  <template slot="show_details" slot-scope="row">
+        	<!-- As `row.showDetails` is one-way, we call the toggleDetails function on @change -->
+        	<b-form-checkbox @change="row.toggleDetails" v-model="row.detailsShowing">
+        	<i class="fas fa-angle-right"></i>
+        	</b-form-checkbox>
+      	  </template>
+		  <template slot="row-details" slot-scope="row">
+		  	<div>
+  				<b-tabs content-class="mt-3">
+    				<b-tab title="Current Questionnaire Response" active>
+	               		<table>
+	             			<tbody>
+	             				<tr>
+	             					<td>1. In the last 12 months, were you worried that your food would run out before you got money to buy more?</td>
+	             					<td>Y</td>
+	             				</tr>
+	             				<tr>
+	             					<td>2. In the last 12 months, did you ever eat less than you felt you should because there wasn’t enough money for food?</td>
+	             					<td>Y</td>
+	             				</tr>
+	             				<tr>
+	             					<td>3. In the last 12 months, were you every hungry but didn’t eat because there wasn’t enough money for food?</td>
+	             					<td>N</td>
+	             				</tr>
+	             				<tr>
+	             					<td>4. In the last 12 months, since last (name of current month), did (you/you or other adults in your household) ever cut the size of your meals or skip meals because there wasn’t enough money for food?</td>
+	             					<td>Y</td>
+	             				</tr>
+	             			</tbody>
+	             		</table>                	
+    				</b-tab>
+    				<b-tab title="Historic Questionnaire Response">
+						<br><p>This might be a clickable list of dates or the menu item might be a dropdown.</p>
+    				</b-tab>
+  				</b-tabs>
+              </div>
+      	   </template>
+		</b-table>
+	</div>
+
 </div>
 
 {{>layout/footer}}

--- a/src/main/resources/static/assets/js/sdh.js
+++ b/src/main/resources/static/assets/js/sdh.js
@@ -2,7 +2,7 @@
 	new Vue({
 		el: '#contents',
 		data: {
-			fields: [{key:'domain', sortable:true}, {key:'date_last_assessed', sortable:true}, {key:'clinician_priority', sortable:true}, {key:'patient_readiness', sortable:true}],
+			fields: [ 'show_details', {key:'domain', sortable:true}, {key:'date_last_assessed', sortable:true}, {key:'clinician_priority', sortable:true}, {key:'patient_readiness', sortable:true}],
 			filters: {
 			      domain: '',
 			      date_last_assessed: '',
@@ -10,7 +10,7 @@
 			      patient_readiness: ''
 			    },
 	        items: [
-	            { domain: 'Food Security', date_last_assessed: '01/01/2018', clinician_priority: 'High', patient_readiness: 'Not Ready' },
+	            { domain: 'Food Security', date_last_assessed: '01/01/2018', clinician_priority: 'Medium', patient_readiness: 'Not Ready' },
 	            { domain: 'Transportation', date_last_assessed: '01/01/2019', clinician_priority: 'Low', patient_readiness: 'Motivated'},
 	            { domain: 'Housing Instability', date_last_assessed: '10/11/2018', clinician_priority: 'Medium', patient_readiness: 'Ready' },
 	            { domain: 'Utilities', date_last_assessed: '02/01/2019', clinician_priority: 'High', patient_readiness: 'Ready' },
@@ -60,6 +60,7 @@
 		    	const { filtered, _priorityVariant, _readinessVariant } = this;
 		    	const emphasized = filtered.map(item => {
 		    		let tmp = Object.assign({}, item);
+		    		tmp._showDetails = false; // Trigger row details with everything closed
 		    		tmp._cellVariants = {
 		    			'clinician_priority': _priorityVariant(item.clinician_priority), 
 		    			'patient_readiness': _readinessVariant(item.patient_readiness)


### PR DESCRIPTION
A few UI tweaks for next week's demo. The static table is now in a different view than the one generated by Bootstrap-Vue. Added a mockup of row details.