### PR TITLE
CIS-1058 2018q3 bump image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "2"
 services:
   app:
-    image: octri.ohsu.edu/jarrunner:2019q2
+    image: octri.ohsu.edu/jarrunner:11
     volumes:
       - ./target/clinch-it.jar:/app.jar
     environment:


### PR DESCRIPTION
Updating to use our Docker Library version of jarrunner. The `11` tag will be updated each quarter so you should only need to `docker-compose pull` to upgrade. We also have a specific tag `11-19.08.0` which is of the form `<jarrunner-version-tag>-<year>.<month>.<image-version>` if we need to pin a version.